### PR TITLE
Display a grayedout team when selecting a new one

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
     "extends": "airbnb",
     "rules": {
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-        "import/no-unresolved": "off"
+        "import/no-unresolved": "off",
+        "react/prop-types": "off"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "extends": "airbnb",
     "rules": {
-        "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+        "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+        "import/no-unresolved": "off"
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react": "16.7.0-alpha.0",
     "react-apollo-hooks": "0.1.1",
     "react-dom": "16.7.0-alpha.0",
+    "react-image-filter": "^0.1.2",
     "react-scripts": "2.1.1"
   },
   "scripts": {

--- a/src/Inbox.js
+++ b/src/Inbox.js
@@ -38,7 +38,6 @@ const Inbox = () => {
       case actions.CHANGE_REPORT:
         return { ...prevState, reportId: action.payload };
       case actions.CHANGE_TEAM:
-        debugger;
         return { ...prevState, previousTeamId: prevState.teamId, teamId: action.payload };
       default:
         return { ...prevState };

--- a/src/Inbox.js
+++ b/src/Inbox.js
@@ -8,9 +8,11 @@ import { filter } from 'graphql-anywhere';
 import Reports from './inbox/Reports';
 import Report from './inbox/Report';
 import Team from './inbox/Team';
+import GrayedoutTeam from './inbox/GrayedoutTeam';
 import Loading from './Loading';
 
 const initialState = {
+  previousTeamId: 'Z2lkOi8vaGFja2Vyb25lL1RlYW0vMTg=',
   teamId: 'Z2lkOi8vaGFja2Vyb25lL1RlYW0vMTg=',
   reportId: 'Z2lkOi8vaGFja2Vyb25lL1JlcG9ydC80MzQxMTY=',
 };
@@ -36,7 +38,8 @@ const Inbox = () => {
       case actions.CHANGE_REPORT:
         return { ...prevState, reportId: action.payload };
       case actions.CHANGE_TEAM:
-        return { ...prevState, teamId: action.payload };
+        debugger;
+        return { ...prevState, previousTeamId: prevState.teamId, teamId: action.payload };
       default:
         return { ...prevState };
     }
@@ -61,9 +64,14 @@ const Inbox = () => {
             <span className="border-right px-3">Substate filter</span>
           </Row>
           {state.teamId && (
+          <Suspense fallback={(
             <Suspense fallback={<Loading />}>
-              <Team teamId={state.teamId} />
+              <GrayedoutTeam teamId={state.previousTeamId} />
             </Suspense>
+)}
+          >
+            <Team teamId={state.teamId} />
+          </Suspense>
           )}
           <Row>
             <Col md="5" className="pt-4">

--- a/src/inbox/GrayedoutTeam.js
+++ b/src/inbox/GrayedoutTeam.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import ImageFilter from 'react-image-filter';
 import {
   Col,
   Card,
@@ -14,14 +15,14 @@ import {
 import gql from 'graphql-tag';
 import { useApolloQuery } from 'react-apollo-hooks';
 
-const Team = ({ teamId }) => {
+const GrayedoutTeam = ({ teamId }) => {
   const {
     data: { team },
   } = useApolloQuery(
     gql`
-      query Team($teamId: ID!) {
+      query GrayedoutTeam($teamId: ID!) {
         team: node(id: $teamId) {
-          ... on Team {
+          ... on GrayedoutTeam {
             id
             name
             handle
@@ -36,20 +37,18 @@ const Team = ({ teamId }) => {
   return (
     <Row className="mt-4">
       <Col md="12">
-        <Fade>
           <Card>
             <CardBody>
-              <img src={team.profilePicture} className="float-left mr-3" />
+            <ImageFilter image={team.profilePicture} filter="grayscale" className="float-left mr-3" />
               <CardText>
                 <h4>{team.name}</h4>
                 <small className="text-muted">Some data</small>
               </CardText>
             </CardBody>
           </Card>
-        </Fade>
       </Col>
     </Row>
   );
 };
 
-export default Team;
+export default GrayedoutTeam;

--- a/src/inbox/GrayedoutTeam.js
+++ b/src/inbox/GrayedoutTeam.js
@@ -1,15 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import ImageFilter from 'react-image-filter';
 import {
   Col,
   Card,
-  Fade,
   Row,
   CardBody,
-  CardHeader,
   CardText,
-  ListGroup,
-  Button,
   ListGroupItem,
 } from 'reactstrap';
 import gql from 'graphql-tag';

--- a/src/inbox/GrayedoutTeam.js
+++ b/src/inbox/GrayedoutTeam.js
@@ -33,15 +33,15 @@ const GrayedoutTeam = ({ teamId }) => {
   return (
     <Row className="mt-4">
       <Col md="12">
-          <Card>
-            <CardBody>
+        <Card>
+          <CardBody>
             <ImageFilter image={team.profilePicture} filter="grayscale" className="float-left mr-3" />
-              <CardText>
-                <h4>{team.name}</h4>
-                <small className="text-muted">Some data</small>
-              </CardText>
-            </CardBody>
-          </Card>
+            <CardText>
+              <h4>{team.name}</h4>
+              <small className="text-muted">Some data</small>
+            </CardText>
+          </CardBody>
+        </Card>
       </Col>
     </Row>
   );


### PR DESCRIPTION
I thought the jumping around of elements when selecting a new team was annoying, so here's an attempt to improve that behavior. What happens is that I show a copy of the team, except with a grayed out profilepicture.

Note that other than the image filter, and the lack of a `<Fade>` wrapper, the new `GrayedoutTeam` component is completely identical to `Team`.

I don't know how to do something about the initial load. Because even the GrayedoutTeam depends on a graphql request to fetch some data, the very first time this component is loaded it will exhibit the elements-jumping-around behavior. If anybody has any thoughts on how to prevent that, I'd love to hear them.